### PR TITLE
Fix back button url

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -39,7 +39,9 @@ document.addEventListener('DOMContentLoaded', function() {
     }
 
     function get_back() {
-        let link = current == 'list' ? 'javascript:history.back()' : '/'
+        let location = window.location
+        let url = `${location.origin}${location.pathname}`
+        let link = current == 'list' ? 'javascript:history.back()' : url
         return `<a href="${link}">${icon_back}</a>`
     }
 
@@ -61,7 +63,7 @@ document.addEventListener('DOMContentLoaded', function() {
                 $('#next').style.display = 'none'
                 total = page
             }
-                
+
             $('#next').removeAttribute('disabled')
             ifPager()
         }
@@ -156,15 +158,15 @@ document.addEventListener('DOMContentLoaded', function() {
             let time = 0
 
             if (scrollY > 0) {
-                window.scroll({ top: 0, left: 0, behavior: 'smooth' }) 
+                window.scroll({ top: 0, left: 0, behavior: 'smooth' })
                 time = 500
             }
 
-            setTimeout(() => { 
+            setTimeout(() => {
                 $('.left').style.display = 'none'
             }, (time + 500))
 
-            setTimeout(() => { 
+            setTimeout(() => {
                 $('.container').classList.remove('single')
                 $('.container').classList.add('post')
             }, time)


### PR DESCRIPTION
Thank you LoeiFy for this awesome tool !
问题场景：用 Mirror 创建的 blog host 在非 username.github.io repo 下面的时候，譬如 host 在名为 blog 的 repo，如果直接访问某篇博文的链接，点击退后按钮会返回到 username.github.io 而非 username.github.io/blog